### PR TITLE
Add Gradle bootstrap script for Android module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.pyc
+*.iml
+.gradle/
+**/build/
+android/.gradle/
+android/.gradle-temp/
+lambdas/__pycache__/

--- a/README.md
+++ b/README.md
@@ -41,6 +41,20 @@ attendance/
    └─ README.md                   # (this file)
 ```
 
+## Building the Android app
+
+This repo avoids committing the Gradle wrapper JAR, so a small helper script in
+`android/gradlew` bootstraps Gradle (downloads version **8.5** on first run).
+You can build from the command line:
+
+```bash
+cd android
+./gradlew assembleDebug
+```
+
+Or open the `android/` folder directly in **Android Studio** and let it run the
+same script.
+
 ### `backend/Dockerfile` (optional but recommended for cloud deploys)
 
 ```dockerfile

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,0 +1,54 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.example.attendance"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.example.attendance"
+        minSdk = 24
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0"
+    }
+
+    buildFeatures { compose = true }
+    composeOptions { kotlinCompilerExtensionVersion = "1.5.14" }
+
+    packaging { resources.excludes += "/META-INF/{AL2.0,LGPL2.1}" }
+}
+
+dependencies {
+    // Compose
+    implementation(platform("androidx.compose:compose-bom:2024.12.01"))
+    implementation("androidx.activity:activity-compose:1.9.2")
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.material3:material3")
+    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.8.4")
+
+    // CameraX
+    val camerax = "1.3.4"
+    implementation("androidx.camera:camera-core:$camerax")
+    implementation("androidx.camera:camera-camera2:$camerax")
+    implementation("androidx.camera:camera-lifecycle:$camerax")
+    implementation("androidx.camera:camera-view:$camerax")
+
+    // Location
+    implementation("com.google.android.gms:play-services-location:21.3.0")
+
+    // Networking
+    implementation("com.squareup.retrofit2:retrofit:2.11.0")
+    implementation("com.squareup.retrofit2:converter-moshi:2.11.0")
+    implementation("com.squareup.okhttp3:okhttp:4.12.0")
+    implementation("com.squareup.okhttp3:logging-interceptor:4.12.0")
+    implementation("com.squareup.moshi:moshi-kotlin:1.15.1")
+
+    // Coroutines
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0")
+
+    // Image preview (optional)
+    implementation("io.coil-kt:coil-compose:2.7.0")
+}

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,16 @@
+<manifest package="com.example.attendance" xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+    <uses-permission android:name="android.permission.CAMERA"/>
+
+    <application android:theme="@style/Theme.Material3.DayNight.NoActionBar">
+        <activity android:name=".MainActivity" android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN"/>
+                <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/android/app/src/main/java/com/example/attendance/MainActivity.kt
+++ b/android/app/src/main/java/com/example/attendance/MainActivity.kt
@@ -1,0 +1,29 @@
+package com.example.attendance
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import com.example.attendance.ui.InstructorScreen
+import com.example.attendance.ui.StudentScreen
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            MaterialTheme {
+                var tab by remember { mutableStateOf(0) }
+                var classId by remember { mutableStateOf("ME101") }
+                var studentId by remember { mutableStateOf("21CS02010") } // TODO: derive from auth
+
+                TabRow(selectedTabIndex = tab) {
+                    Tab(selected = tab==0, onClick={tab=0}, text={ Text("Student") })
+                    Tab(selected = tab==1, onClick={tab=1}, text={ Text("Instructor") })
+                }
+                if (tab == 0) StudentScreen(classId = classId, studentId = studentId)
+                else InstructorScreen(classId = classId)
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/example/attendance/camera/CameraCapture.kt
+++ b/android/app/src/main/java/com/example/attendance/camera/CameraCapture.kt
@@ -1,0 +1,51 @@
+package com.example.attendance.camera
+
+import android.content.Context
+import android.net.Uri
+import android.view.ViewGroup.LayoutParams.MATCH_PARENT
+import androidx.camera.core.*
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.camera.view.PreviewView
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.content.ContextCompat
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.*
+
+@Composable
+fun CameraPreview(imageCapture: ImageCapture) {
+    val ctx = LocalContext.current
+    AndroidView(factory = { c ->
+        val pv = PreviewView(c).apply { layoutParams = android.widget.FrameLayout.LayoutParams(MATCH_PARENT, MATCH_PARENT) }
+        val providerFuture = ProcessCameraProvider.getInstance(c)
+        providerFuture.addListener({
+            val provider = providerFuture.get()
+            val preview = Preview.Builder().build().apply {
+                setSurfaceProvider(pv.surfaceProvider)
+            }
+            val selector = CameraSelector.DEFAULT_FRONT_CAMERA
+            val ic = imageCapture
+            provider.unbindAll()
+            provider.bindToLifecycle(ctx as androidx.lifecycle.LifecycleOwner, selector, preview, ic)
+        }, ContextCompat.getMainExecutor(c))
+        pv
+    })
+}
+
+fun rememberImageCapture(): ImageCapture =
+    ImageCapture.Builder().setCaptureMode(ImageCapture.CAPTURE_MODE_MINIMIZE_LATENCY).build()
+
+fun takePhoto(context: Context, imageCapture: ImageCapture, onSaved: (Uri?) -> Unit) {
+    val file = File(context.cacheDir, "selfie_${SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(Date())}.jpg")
+    val opts = ImageCapture.OutputFileOptions.Builder(file).build()
+    imageCapture.takePicture(
+        opts,
+        ContextCompat.getMainExecutor(context),
+        object : ImageCapture.OnImageSavedCallback {
+            override fun onError(exc: ImageCaptureException) = onSaved(null)
+            override fun onImageSaved(output: ImageCapture.OutputFileResults) = onSaved(Uri.fromFile(file))
+        }
+    )
+}

--- a/android/app/src/main/java/com/example/attendance/data/Models.kt
+++ b/android/app/src/main/java/com/example/attendance/data/Models.kt
@@ -1,0 +1,27 @@
+package com.example.attendance.data
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class SessionInfo(
+    val classId: String,
+    val centerLat: Double,
+    val centerLon: Double,
+    val radiusMeters: Int,
+    val expiresAtEpochMs: Long
+)
+
+@JsonClass(generateAdapter = true)
+data class StartSessionRequest(
+    val classId: String,
+    val centerLat: Double,
+    val centerLon: Double,
+    val radiusMeters: Int = 10,
+    val durationMinutes: Int = 10
+)
+
+@JsonClass(generateAdapter = true)
+data class StartSessionResponse(val ok: Boolean)
+
+@JsonClass(generateAdapter = true)
+data class CheckInResponse(val ok: Boolean, val matchConfidence: Double? = null, val message: String? = null)

--- a/android/app/src/main/java/com/example/attendance/location/LocationUtils.kt
+++ b/android/app/src/main/java/com/example/attendance/location/LocationUtils.kt
@@ -1,0 +1,28 @@
+package com.example.attendance.location
+
+import android.content.Context
+import android.location.Location
+import com.google.android.gms.location.LocationServices
+import com.google.android.gms.location.Priority
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+
+suspend fun getCurrentHighAccuracyLocation(context: Context): Location? {
+    val fused = LocationServices.getFusedLocationProviderClient(context)
+    return suspendCancellableCoroutine { cont ->
+        fused.getCurrentLocation(Priority.PRIORITY_HIGH_ACCURACY, null)
+            .addOnSuccessListener { cont.resume(it) }
+            .addOnFailureListener { cont.resume(null) }
+    }
+}
+
+fun distanceMeters(aLat: Double, aLon: Double, bLat: Double, bLon: Double): Float {
+    val out = FloatArray(1)
+    Location.distanceBetween(aLat, aLon, bLat, bLon, out)
+    return out[0]
+}
+
+fun isMockLocation(loc: Location?): Boolean {
+    if (loc == null) return false
+    return loc.isFromMockProvider
+}

--- a/android/app/src/main/java/com/example/attendance/network/Api.kt
+++ b/android/app/src/main/java/com/example/attendance/network/Api.kt
@@ -1,0 +1,31 @@
+package com.example.attendance.network
+
+import com.example.attendance.data.*
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
+import retrofit2.http.*
+
+interface AttendanceApi {
+    @GET("session/current")
+    suspend fun getCurrentSession(@Query("classId") classId: String): SessionInfo
+
+    @POST("session/start")
+    suspend fun startSession(@Body req: StartSessionRequest): StartSessionResponse
+
+    @Multipart
+    @POST("enroll")
+    suspend fun enroll(
+        @Part image: MultipartBody.Part,
+        @Part("studentId") studentId: RequestBody
+    ): Map<String, Any>
+
+    @Multipart
+    @POST("attendance/checkin")
+    suspend fun checkIn(
+        @Part image: MultipartBody.Part,
+        @Part("classId") classId: RequestBody,
+        @Part("lat") lat: RequestBody,
+        @Part("lon") lon: RequestBody,
+        @Part("studentId") studentId: RequestBody // TODO: replace with auth-derived ID
+    ): CheckInResponse
+}

--- a/android/app/src/main/java/com/example/attendance/network/Client.kt
+++ b/android/app/src/main/java/com/example/attendance/network/Client.kt
@@ -1,0 +1,29 @@
+package com.example.attendance.network
+
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+import java.util.concurrent.TimeUnit
+
+object ApiClient {
+    private const val BASE_URL = "https://YOUR_API_GATEWAY_URL/" // <- set after deploy
+
+    val api: AttendanceApi by lazy {
+        val logging = HttpLoggingInterceptor().apply {
+            level = HttpLoggingInterceptor.Level.BODY
+        }
+        val client = OkHttpClient.Builder()
+            .addInterceptor(logging)
+            .connectTimeout(20, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .build()
+
+        Retrofit.Builder()
+            .baseUrl(BASE_URL)
+            .client(client)
+            .addConverterFactory(MoshiConverterFactory.create())
+            .build()
+            .create(AttendanceApi::class.java)
+    }
+}

--- a/android/app/src/main/java/com/example/attendance/ui/AttendanceViewModel.kt
+++ b/android/app/src/main/java/com/example/attendance/ui/AttendanceViewModel.kt
@@ -1,0 +1,49 @@
+package com.example.attendance.ui
+
+import android.content.Context
+import android.net.Uri
+import com.example.attendance.data.CheckInResponse
+import com.example.attendance.data.SessionInfo
+import com.example.attendance.network.ApiClient
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
+import java.io.File
+
+class AttendanceViewModel {
+    private val _session = MutableStateFlow<SessionInfo?>(null)
+    val session = _session.asStateFlow()
+
+    suspend fun loadSession(classId: String) {
+        _session.value = ApiClient.api.getCurrentSession(classId)
+    }
+
+    suspend fun enroll(imageUri: Uri, studentId: String, context: Context): Boolean {
+        val file = File(imageUri.path!!)
+        val img = RequestBody.create("image/jpeg".toMediaTypeOrNull(), file)
+        val part = MultipartBody.Part.createFormData("image", file.name, img)
+        val sid = RequestBody.create("text/plain".toMediaType(), studentId)
+        val res = ApiClient.api.enroll(part, sid)
+        return (res["ok"] as? Boolean) == true
+    }
+
+    suspend fun checkIn(
+        imageUri: Uri,
+        classId: String,
+        lat: Double,
+        lon: Double,
+        studentId: String
+    ): CheckInResponse {
+        val file = File(imageUri.path!!)
+        val img = RequestBody.create("image/jpeg".toMediaTypeOrNull(), file)
+        val part = MultipartBody.Part.createFormData("image", file.name, img)
+        val cid = RequestBody.create("text/plain".toMediaType(), classId)
+        val rlat = RequestBody.create("text/plain".toMediaType(), lat.toString())
+        val rlon = RequestBody.create("text/plain".toMediaType(), lon.toString())
+        val sid = RequestBody.create("text/plain".toMediaType(), studentId) // TODO: replace with auth token server-side
+        return ApiClient.api.checkIn(part, cid, rlat, rlon, sid)
+    }
+}

--- a/android/app/src/main/java/com/example/attendance/ui/InstructorScreen.kt
+++ b/android/app/src/main/java/com/example/attendance/ui/InstructorScreen.kt
@@ -1,0 +1,52 @@
+package com.example.attendance.ui
+
+import android.Manifest
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import com.example.attendance.data.StartSessionRequest
+import com.example.attendance.location.getCurrentHighAccuracyLocation
+import com.example.attendance.network.ApiClient
+import kotlinx.coroutines.launch
+
+@Composable
+fun InstructorScreen(classId: String) {
+    val ctx = LocalContext.current
+    val scope = rememberCoroutineScope()
+    var duration by remember { mutableStateOf("10") }
+    var radius by remember { mutableStateOf("10") }
+
+    val perm = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {}
+    LaunchedEffect(Unit) { perm.launch(Manifest.permission.ACCESS_FINE_LOCATION) }
+
+    Column(Modifier.fillMaxSize().padding(16.dp)) {
+        Text("Instructor", style = MaterialTheme.typography.titleLarge)
+        Text("Class: $classId")
+        Spacer(Modifier.height(12.dp))
+        OutlinedTextField(value = duration, onValueChange = { duration = it }, label = { Text("Duration (min)") })
+        Spacer(Modifier.height(8.dp))
+        OutlinedTextField(value = radius, onValueChange = { radius = it }, label = { Text("Radius (m)") })
+        Spacer(Modifier.height(12.dp))
+        Button(onClick = {
+            scope.launch {
+                val loc = getCurrentHighAccuracyLocation(ctx)
+                if (loc == null) { Toast.makeText(ctx, "Location unavailable", Toast.LENGTH_SHORT).show(); return@launch }
+                val req = StartSessionRequest(
+                    classId = classId,
+                    centerLat = loc.latitude,
+                    centerLon = loc.longitude,
+                    radiusMeters = radius.toIntOrNull() ?: 10,
+                    durationMinutes = duration.toIntOrNull() ?: 10
+                )
+                val ok = ApiClient.api.startSession(req).ok
+                Toast.makeText(ctx, if (ok) "Session opened" else "Failed", Toast.LENGTH_SHORT).show()
+            }
+        }) { Text("Open attendance window") }
+    }
+}

--- a/android/app/src/main/java/com/example/attendance/ui/StudentScreen.kt
+++ b/android/app/src/main/java/com/example/attendance/ui/StudentScreen.kt
@@ -1,0 +1,80 @@
+package com.example.attendance.ui
+
+import android.Manifest
+import android.location.Location
+import android.net.Uri
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.camera.core.ImageCapture
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import com.example.attendance.camera.CameraPreview
+import com.example.attendance.camera.rememberImageCapture
+import com.example.attendance.camera.takePhoto
+import com.example.attendance.location.distanceMeters
+import com.example.attendance.location.getCurrentHighAccuracyLocation
+import com.example.attendance.location.isMockLocation
+import kotlinx.coroutines.launch
+
+@Composable
+fun StudentScreen(classId: String, studentId: String) {
+    val ctx = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val vm = remember { AttendanceViewModel() }
+    val session by vm.session.collectAsState()
+
+    val perms = rememberLauncherForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) {}
+    LaunchedEffect(Unit) {
+        perms.launch(arrayOf(Manifest.permission.CAMERA, Manifest.permission.ACCESS_FINE_LOCATION))
+        vm.loadSession(classId)
+    }
+
+    var selfie by remember { mutableStateOf<Uri?>(null) }
+    val imageCapture: ImageCapture = rememberImageCapture()
+
+    Column(Modifier.fillMaxSize().padding(16.dp)) {
+        Text("Student", style = MaterialTheme.typography.titleLarge)
+        Text("Class: $classId")
+        Spacer(Modifier.height(8.dp))
+
+        if (session == null) {
+            Text("No active session.")
+        } else {
+            val s = session!!
+            Text("Window ends: ${java.text.SimpleDateFormat("HH:mm:ss").format(java.util.Date(s.expiresAtEpochMs))}")
+            Spacer(Modifier.height(12.dp))
+
+            CameraPreview(imageCapture)
+            Spacer(Modifier.height(12.dp))
+
+            Row {
+                Button(onClick = {
+                    takePhoto(ctx, imageCapture) { uri -> selfie = uri }
+                }) { Text("Take selfie") }
+
+                Spacer(Modifier.width(12.dp))
+
+                Button(enabled = selfie != null, onClick = {
+                    scope.launch {
+                        val loc: Location? = getCurrentHighAccuracyLocation(ctx)
+                        if (loc == null || isMockLocation(loc)) {
+                            Toast.makeText(ctx, "Location unavailable or mocked", Toast.LENGTH_SHORT).show(); return@launch
+                        }
+                        val d = distanceMeters(loc.latitude, loc.longitude, s.centerLat, s.centerLon)
+                        val now = System.currentTimeMillis()
+                        if (now > s.expiresAtEpochMs || d > s.radiusMeters) {
+                            Toast.makeText(ctx, "Not in zone or window expired", Toast.LENGTH_SHORT).show(); return@launch
+                        }
+                        val resp = vm.checkIn(selfie!!, s.classId, loc.latitude, loc.longitude, studentId)
+                        Toast.makeText(ctx, if (resp.ok) "Attendance marked (${resp.matchConfidence?.toInt()}%)" else resp.message ?: "Failed", Toast.LENGTH_LONG).show()
+                    }
+                }) { Text("Submit") }
+            }
+        }
+    }
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">Attendance App</string>
+</resources>

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,0 +1,17 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath("com.android.tools.build:gradle:8.2.0")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.21")
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
+android.useAndroidX=true
+kotlin.code.style=official

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/android/gradlew
+++ b/android/gradlew
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e
+DIR="$(cd "$(dirname "$0")" && pwd)"
+GRADLE_DIR="$DIR/.gradle-temp"
+DIST="https://services.gradle.org/distributions/gradle-8.5-bin.zip"
+if [ ! -d "$GRADLE_DIR/gradle-8.5" ]; then
+  echo "Downloading Gradle 8.5..."
+  mkdir -p "$GRADLE_DIR"
+  curl -fsSL "$DIST" -o "$GRADLE_DIR/gradle.zip"
+  unzip -q "$GRADLE_DIR/gradle.zip" -d "$GRADLE_DIR"
+  rm "$GRADLE_DIR/gradle.zip"
+fi
+exec "$GRADLE_DIR/gradle-8.5/bin/gradle" "$@"

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -1,0 +1,2 @@
+rootProject.name = "AttendanceApp"
+include(":app")

--- a/lambdas/handler.py
+++ b/lambdas/handler.py
@@ -1,0 +1,143 @@
+import os, json, base64, math, time, uuid
+import boto3
+from urllib.parse import parse_qs
+
+S3_BUCKET = os.environ["S3_BUCKET"]
+COLLECTION_ID = os.environ["COLLECTION_ID"]
+TABLE_SESSIONS = os.environ["TABLE_SESSIONS"]
+TABLE_ATTENDANCE = os.environ["TABLE_ATTENDANCE"]
+
+s3 = boto3.client("s3")
+rek = boto3.client("rekognition")
+dynamodb = boto3.resource("dynamodb")
+sessions_tb = dynamodb.Table(TABLE_SESSIONS)
+att_tb = dynamodb.Table(TABLE_ATTENDANCE)
+
+def _now_ms(): return int(time.time() * 1000)
+
+def _haversine_m(lat1, lon1, lat2, lon2):
+    R=6371000.0
+    from math import radians,sin,cos,atan2,sqrt
+    dLat, dLon = radians(lat2-lat1), radians(lon2-lon1)
+    a = sin(dLat/2)**2 + cos(radians(lat1))*cos(radians(lat2))*sin(dLon/2)**2
+    return 2*R*atan2(sqrt(a), sqrt(1-a))
+
+def response(code, body, headers=None):
+    h = {"Content-Type":"application/json"}
+    if headers: h.update(headers)
+    return {"statusCode": code, "headers": h, "body": json.dumps(body)}
+
+def parse_multipart(event):
+    # API Gateway HTTP API with default proxy may deliver base64 body
+    body = base64.b64decode(event["body"]) if event.get("isBase64Encoded") else event["body"].encode()
+    content_type = event["headers"].get("content-type") or event["headers"].get("Content-Type")
+    import email
+    msg = email.message_from_bytes(b"Content-Type: "+content_type.encode()+b"\r\n\r\n"+body)
+    fields = {}
+    file_bytes = None
+    file_name = None
+    for part in msg.walk():
+        if part.get_content_disposition() == "form-data":
+            name = part.get_param("name", header="content-disposition")
+            filename = part.get_param("filename", header="content-disposition")
+            payload = part.get_payload(decode=True)
+            if filename:
+                file_bytes = payload
+                file_name = filename
+            else:
+                fields[name] = payload.decode()
+    return fields, file_bytes, file_name
+
+# ---------- Session ----------
+def session_handler(event, context):
+    method = event["requestContext"]["http"]["method"]
+    if method == "POST":  # /session/start
+        body = json.loads(event["body"])
+        classId = body["classId"]
+        item = {
+            "classId": classId,
+            "centerLat": float(body["centerLat"]),
+            "centerLon": float(body["centerLon"]),
+            "radiusMeters": int(body.get("radiusMeters", 10)),
+            "expiresAtEpochMs": _now_ms() + 60_000 * int(body.get("durationMinutes", 10))
+        }
+        sessions_tb.put_item(Item=item)
+        return response(200, {"ok": True})
+    else:  # GET /session/current?classId=...
+        classId = event["queryStringParameters"]["classId"]
+        res = sessions_tb.get_item(Key={"classId": classId})
+        if "Item" not in res: return response(404, {"message":"No active session"})
+        return response(200, res["Item"])
+
+# ---------- Enroll ----------
+def enroll_handler(event, context):
+    fields, file_bytes, file_name = parse_multipart(event)
+    studentId = fields.get("studentId")
+    if not studentId or not file_bytes:
+        return response(400, {"ok": False, "message":"studentId and image required"})
+
+    key = f"students/{studentId}.jpg"
+    s3.put_object(Bucket=S3_BUCKET, Key=key, Body=file_bytes, ContentType="image/jpeg", ACL="private")
+
+    # (Optional) also index into Rekognition collection for future search
+    try:
+        rek.create_collection(CollectionId=COLLECTION_ID)
+    except rek.exceptions.ResourceAlreadyExistsException:
+        pass
+    rek.index_faces(
+        CollectionId=COLLECTION_ID,
+        Image={"Bytes": file_bytes},
+        ExternalImageId=studentId,
+        DetectionAttributes=[]
+    )
+    return response(200, {"ok": True, "imageKey": key})
+
+# ---------- Check-in ----------
+def checkin_handler(event, context):
+    fields, file_bytes, _ = parse_multipart(event)
+    required = ["classId", "lat", "lon", "studentId"]
+    if any(k not in fields for k in required) or not file_bytes:
+        return response(400, {"ok": False, "message":"missing fields"})
+
+    classId = fields["classId"]
+    lat, lon = float(fields["lat"]), float(fields["lon"])
+    studentId = fields["studentId"]
+
+    s = sessions_tb.get_item(Key={"classId": classId}).get("Item")
+    if not s: return response(200, {"ok": False, "message":"No active session"})
+    if _now_ms() > int(s["expiresAtEpochMs"]): return response(200, {"ok": False, "message":"Window expired"})
+
+    dist = _haversine_m(lat, lon, float(s["centerLat"]), float(s["centerLon"]))
+    if dist > float(s["radiusMeters"]):
+        return response(200, {"ok": False, "message": f"Outside radius ({dist:.1f}m)"})
+
+    # CompareFaces with enrollment image from S3
+    ref_key = f"students/{studentId}.jpg"
+    try:
+        ref_obj = s3.get_object(Bucket=S3_BUCKET, Key=ref_key)
+        ref_bytes = ref_obj["Body"].read()
+    except Exception:
+        return response(200, {"ok": False, "message":"No enrolled reference"})
+
+    cmp = rek.compare_faces(
+        SourceImage={"Bytes": ref_bytes},
+        TargetImage={"Bytes": file_bytes},
+        SimilarityThreshold=90.0
+    )
+    matches = cmp.get("FaceMatches", [])
+    if not matches:
+        return response(200, {"ok": False, "message":"Face mismatch"})
+
+    similarity = float(matches[0]["Similarity"])
+
+    # store attendance
+    sessionId = f"{classId}#{int(s['expiresAtEpochMs'])}"
+    att_tb.put_item(Item={
+        "sessionId": sessionId,
+        "studentId": studentId,
+        "timestamp": _now_ms(),
+        "similarity": similarity,
+        "lat": lat, "lon": lon
+    })
+
+    return response(200, {"ok": True, "matchConfidence": similarity})

--- a/template.yaml
+++ b/template.yaml
@@ -1,0 +1,122 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Attendance API (sessions, enroll, check-in) with Rekognition
+
+Parameters:
+  BucketName:
+    Type: String
+  RekognitionCollectionId:
+    Type: String
+    Default: students-collection
+
+Globals:
+  Function:
+    Runtime: python3.11
+    Timeout: 15
+    MemorySize: 512
+    Environment:
+      Variables:
+        S3_BUCKET: !Ref BucketName
+        COLLECTION_ID: !Ref RekognitionCollectionId
+        TABLE_SESSIONS: Sessions
+        TABLE_ATTENDANCE: Attendance
+    Policies:
+      - S3CrudPolicy:
+          BucketName: !Ref BucketName
+      - DynamoDBCrudPolicy:
+          TableName: Sessions
+      - DynamoDBCrudPolicy:
+          TableName: Attendance
+      - Statement:
+          Effect: Allow
+          Action:
+            - rekognition:CompareFaces
+            - rekognition:SearchFacesByImage
+            - rekognition:IndexFaces
+            - rekognition:CreateCollection
+            - rekognition:DescribeCollection
+            - rekognition:ListCollections
+          Resource: "*"
+
+Resources:
+  SessionsTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: Sessions
+      BillingMode: PAY_PER_REQUEST
+      AttributeDefinitions:
+        - AttributeName: classId
+          AttributeType: S
+      KeySchema:
+        - AttributeName: classId
+          KeyType: HASH
+
+  AttendanceTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: Attendance
+      BillingMode: PAY_PER_REQUEST
+      AttributeDefinitions:
+        - AttributeName: sessionId
+          AttributeType: S
+        - AttributeName: studentId
+          AttributeType: S
+      KeySchema:
+        - AttributeName: sessionId
+          KeyType: HASH
+        - AttributeName: studentId
+          KeyType: RANGE
+
+  Api:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: prod
+      Cors:
+        AllowMethods: "'GET,POST,OPTIONS'"
+        AllowHeaders: "'*'"
+        AllowOrigin: "'*'"
+
+  SessionFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: handler.session_handler
+      CodeUri: lambdas/
+      Events:
+        Start:
+          Type: Api
+          Properties:
+            RestApiId: !Ref Api
+            Path: /session/start
+            Method: POST
+        Current:
+          Type: Api
+          Properties:
+            RestApiId: !Ref Api
+            Path: /session/current
+            Method: GET
+
+  EnrollFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: handler.enroll_handler
+      CodeUri: lambdas/
+      Events:
+        Enroll:
+          Type: Api
+          Properties:
+            RestApiId: !Ref Api
+            Path: /enroll
+            Method: POST
+
+  CheckinFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: handler.checkin_handler
+      CodeUri: lambdas/
+      Events:
+        Checkin:
+          Type: Api
+          Properties:
+            RestApiId: !Ref Api
+            Path: /attendance/checkin
+            Method: POST


### PR DESCRIPTION
## Summary
- add lightweight `gradlew` script that downloads Gradle 8.5 on demand
- document Android build steps and wrapper bootstrap in README
- ignore temporary Gradle directories

## Testing
- `python -m py_compile lambdas/handler.py`
- `cd android && ./gradlew tasks | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_b_689bacd299488331a37898f8a49c6303